### PR TITLE
Fix test errors

### DIFF
--- a/example_addon_test_harness_suite_test.go
+++ b/example_addon_test_harness_suite_test.go
@@ -4,11 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e-example-test-harness/pkg/metadata"
-
 	_ "github.com/openshift/osde2e-example-test-harness/pkg/tests"
 )
 
@@ -20,9 +18,10 @@ const (
 
 func TestExampleAddonTestHarness(t *testing.T) {
 	RegisterFailHandler(Fail)
-	jUnitReporter := reporters.NewJUnitReporter(filepath.Join(testResultsDirectory, jUnitOutputFilename))
 
-	RunSpecsWithDefaultAndCustomReporters(t, "Example Addon Test Harness", []Reporter{jUnitReporter})
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = filepath.Join(testResultsDirectory, jUnitOutputFilename)
+	RunSpecs(t, "Example Addon Test Harness", suiteConfig, reporterConfig)
 
 	err := metadata.Instance.WriteToJSON(filepath.Join(testResultsDirectory, addonMetadataName))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/openshift/osde2e-example-test-harness
 go 1.16
 
 require (
-	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.17.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect


### PR DESCRIPTION


---
Currently, periodic osde2e job for test harness is throwing the following error
```
/osde2e-example-test-harness.test flag redefined: ginkgo.seed
panic: /osde2e-example-test-harness.test flag redefined: ginkgo.seed

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc00007a180, 0x16683f8, 0x1f6e620, 0xc000040c80, 0xb, 0x14f5175, 0x2a)
	/usr/local/go/src/flag/flag.go:871 +0x485
flag.(*FlagSet).Int64Var(...)
	/usr/local/go/src/flag/flag.go:682
```

This is due to multiple versions of ginkgo (v1, v2) being imported and `ginkgo.seed` thus being redefined by both. 

This change removes the v1 usage of ginkgo and uses v2 instead. 