### PR TITLE
SDCICD-831 Example secret test

### DIFF
--- a/pkg/tests/example_addon_tests.go
+++ b/pkg/tests/example_addon_tests.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubernetes "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 
 	"k8s.io/client-go/rest"
 )
@@ -43,10 +43,12 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	}, float64(30))
 
-	ginkgo.It("Example secret exists", func() {
+	ginkgo.It("Example passthrough secret exists", func() {
 		k8s, err := kubernetes.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = k8s.CoreV1().Secrets("osde2e-ci-secrets").Get("example-addon-secret", v1.GetOptions{})
+		sec, err := k8s.CoreV1().Secrets("osde2e-ci-secrets").Get("ci-secrets", v1.GetOptions{})
+
+		Expect(sec.Data["testkey"]).ToNot(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 
 	}, float64(30))

--- a/pkg/tests/example_addon_tests.go
+++ b/pkg/tests/example_addon_tests.go
@@ -9,6 +9,8 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes"
+
 	"k8s.io/client-go/rest"
 )
 
@@ -23,7 +25,7 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 		panic(err)
 	}
 
-	ginkgo.It(crdName+" CRD exists", func() {
+	ginkgo.It("Example CRD - "+crdName+" - exists", func() {
 		apiextensions, err := clientset.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -40,4 +42,13 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 	}, float64(30))
+
+	ginkgo.It("Example secret exists", func() {
+		k8s, err := kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = k8s.CoreV1().Secrets("osde2e-ci-secrets").Get("example-addon-secret", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+	}, float64(30))
+
 })


### PR DESCRIPTION
Adds a test   to assert that example passthough key is added to `ci-secrets`  secret in `osde2e-ci-secrets` namespace. 

Use in pipeline `osde2e-rosa-stage-example-addon` depends on vault `kv>selfservice>osde2e-secrets>example-addon-secret`
 
To test locally, run
`./osde2e test --secret-locations /usr/local/osde2e-common,/usr/local/example-addon-secret --configs rosa,stage,addon-suite  --must-gather false --destroy-cluster false --skip-health-check true` 

with env vars
ROSA_ENV=stage;ADDON_IDS=reference-addon;ADDON_TEST_HARNESSES=quay.io/rmundhe_oc/osde2e-example-test-harness;SKIP_CLUSTER_HEALTH_CHECKS=true;CLUSTER_ID=[Your stage cluster id]

Pod logs should show

```
Will run 2 of 2 specs
 [......]
Ran 2 of 2 Specs in [ somewhere around 0.024] seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```