### PR TITLE
changed namespace to `ci`

### DIFF
--- a/pkg/tests/example_addon_tests.go
+++ b/pkg/tests/example_addon_tests.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 	ginkgo.It("Example passthrough secret exists", func() {
 		k8s, err := kubernetes.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred())
-		sec, err := k8s.CoreV1().Secrets("ci").Get("ci-secrets", v1.GetOptions{})
+		sec, err := k8s.CoreV1().Secrets("ci").Get("example-addon-secret", v1.GetOptions{})
 
 		Expect(sec.Data["testkey"]).ToNot(BeNil())
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/tests/example_addon_tests.go
+++ b/pkg/tests/example_addon_tests.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 	ginkgo.It("Example passthrough secret exists", func() {
 		k8s, err := kubernetes.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred())
-		sec, err := k8s.CoreV1().Secrets("osde2e-ci-secrets").Get("ci-secrets", v1.GetOptions{})
+		sec, err := k8s.CoreV1().Secrets("ci").Get("ci-secrets", v1.GetOptions{})
 
 		Expect(sec.Data["testkey"]).ToNot(BeNil())
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fix for test added in [sdcicd-831](https://issues.redhat.com//browse/sdcicd-831)

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/osde2e-rosa-stage-example-addon/1594329807162707968/artifacts/install/containerLogs/addon-tests-17jyg-sn5pz-addon-tests.log


currently failing because the job can't find loaded secrets. Changed namespace to `ci` used for handcrafted osde2e jobs. 