### PR TITLE
SDCICD-961: Remove deprecated ginkgo.It node float64 timeout

### DIFF
--- a/pkg/tests/example_addon_tests.go
+++ b/pkg/tests/example_addon_tests.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 		}
 
 		Expect(err).NotTo(HaveOccurred())
-	}, float64(30))
+	})
 
 	ginkgo.It("Example passthrough secret exists", func() {
 		k8s, err := kubernetes.NewForConfig(config)
@@ -51,6 +51,6 @@ var _ = ginkgo.Describe("Example Addon Tests", func() {
 		Expect(sec.Data["testkey"]).ToNot(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 
-	}, float64(30))
+	})
 
 })


### PR DESCRIPTION
# Change
With ginkgo v2 passing a timeout of type float64 has been [deprecated](https://github.com/onsi/ginkgo/blob/master/internal/node.go#L231-L232). If a test requires a timeout to be passed, it should use either the SpecTimeout or NodeTimeout decorators.

This PR removes the deprecated timeout being passed to ginkgo for these example tests.

For [SDCICD-961](https://issues.redhat.com/browse/SDCICD-961)