### PR TITLE
Bump go version and container image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 ENV PKG=/go/src/github.com/openshift/osde2e-example-test-harness/
 WORKDIR ${PKG}
@@ -7,7 +7,7 @@ WORKDIR ${PKG}
 COPY . .
 RUN make
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/openshift/osde2e-example-test-harness/osde2e-example-test-harness.test osde2e-example-test-harness.test
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ build:
 	CGO_ENABLED=0 go test -v -c
 
 lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
 	(cd "$(DIR)"; golangci-lint run -c .ci-operator.yaml ./...)
 

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,36 @@
 module github.com/openshift/osde2e-example-test-harness
 
-go 1.16
+go 1.19
 
 require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.17.0
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	k8s.io/apiextensions-apiserver v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
+	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.5.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.17.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/utils v0.0.0-20200109141947-94aeca20bf09 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )


### PR DESCRIPTION
# Change
This PR keeps this example test harness up to date by:
 * Bump go to version 1.19 as its one of the stable versions currently supported
 * Bump golang image to 1.19 and to match boilerplate
 * Bump ubi image to ub8 as ubi7 is EOL and to match boilerplate
 * Always install latest golangci-lint

Also [PR](https://github.com/openshift/release/pull/39028) opened to release repo to bump image tag to 1.19 also.